### PR TITLE
fix persistent flags

### DIFF
--- a/clidocstool.go
+++ b/clidocstool.go
@@ -22,6 +22,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	// AnnotationExternalUrl specifies an external link annotation
+	AnnotationExternalUrl = "docs.external.url"
+)
+
 // Options defines options for cli-docs-tool
 type Options struct {
 	Root      *cobra.Command

--- a/clidocstool.go
+++ b/clidocstool.go
@@ -80,25 +80,6 @@ func (c *Client) GenAllTree() error {
 	return nil
 }
 
-// DisableFlagsInUseLine sets the DisableFlagsInUseLine flag on all
-// commands within the tree rooted at cmd.
-func (c *Client) DisableFlagsInUseLine() {
-	visitAll(c.root, func(ccmd *cobra.Command) {
-		// do not add a `[flags]` to the end of the usage line.
-		ccmd.DisableFlagsInUseLine = true
-	})
-}
-
-// visitAll traverses all commands from the root.
-// This is different from the VisitAll of cobra.Command where only parents
-// are checked.
-func visitAll(root *cobra.Command, fn func(*cobra.Command)) {
-	for _, cmd := range root.Commands() {
-		visitAll(cmd, fn)
-	}
-	fn(root)
-}
-
 func fileExists(f string) bool {
 	info, err := os.Stat(f)
 	if os.IsNotExist(err) {

--- a/clidocstool_md.go
+++ b/clidocstool_md.go
@@ -37,6 +37,9 @@ func (c *Client) GenMarkdownTree(cmd *cobra.Command) error {
 		}
 	}
 
+	// always disable the addition of [flags] to the usage
+	cmd.DisableFlagsInUseLine = true
+
 	// Skip the root command altogether, to prevent generating a useless
 	// md file for plugins.
 	if c.plugin && !cmd.HasParent() {

--- a/clidocstool_md.go
+++ b/clidocstool_md.go
@@ -117,7 +117,7 @@ func mdFilename(cmd *cobra.Command) string {
 
 func mdMakeLink(txt, link string, f *pflag.Flag, isAnchor bool) string {
 	link = "#" + link
-	annotations, ok := f.Annotations["docs.external.url"]
+	annotations, ok := f.Annotations[AnnotationExternalUrl]
 	if ok && len(annotations) > 0 {
 		link = annotations[0]
 	} else {
@@ -158,11 +158,10 @@ func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 		fmt.Fprint(b, "\n\n")
 	}
 
-	hasFlags := cmd.Flags().HasAvailableFlags()
-
+	// add inherited flags before checking for flags availability
 	cmd.Flags().AddFlagSet(cmd.InheritedFlags())
 
-	if hasFlags {
+	if cmd.Flags().HasAvailableFlags() {
 		fmt.Fprint(b, "### Options\n\n")
 		fmt.Fprint(b, "| Name | Description |\n")
 		fmt.Fprint(b, "| --- | --- |\n")

--- a/clidocstool_md_test.go
+++ b/clidocstool_md_test.go
@@ -39,7 +39,7 @@ func TestGenMarkdownTree(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.GenMarkdownTree(buildxCmd))
 
-	for _, tt := range []string{"buildx.md", "buildx_build.md"} {
+	for _, tt := range []string{"buildx.md", "buildx_build.md", "buildx_stop.md"} {
 		tt := tt
 		t.Run(tt, func(t *testing.T) {
 			fres := filepath.Join(tmpdir, tt)

--- a/clidocstool_yaml.go
+++ b/clidocstool_yaml.go
@@ -97,6 +97,9 @@ func (c *Client) genYamlTreeCustom(cmd *cobra.Command, filePrepender func(string
 		}
 	}
 
+	// always disable the addition of [flags] to the usage
+	cmd.DisableFlagsInUseLine = true
+
 	// The "root" command used in the generator is just a "stub", and only has a
 	// list of subcommands, but not (e.g.) global options/flags. We should fix
 	// that, so that the YAML file for the docker "root" command contains the

--- a/clidocstool_yaml.go
+++ b/clidocstool_yaml.go
@@ -140,6 +140,10 @@ func (c *Client) genYamlCustom(cmd *cobra.Command, w io.Writer) error {
 		longMaxWidth = 74
 	)
 
+	// necessary to add inherited flags otherwise some
+	// fields are not properly declared like usage
+	cmd.Flags().AddFlagSet(cmd.InheritedFlags())
+
 	cliDoc := cmdDoc{
 		Name:       cmd.CommandPath(),
 		Aliases:    strings.Join(cmd.Aliases, ", "),
@@ -259,7 +263,7 @@ func genFlagResult(flags *pflag.FlagSet, anchors map[string]struct{}) []cmdOptio
 			Deprecated:   len(flag.Deprecated) > 0,
 		}
 
-		if v, ok := flag.Annotations["docs.external.url"]; ok && len(v) > 0 {
+		if v, ok := flag.Annotations[AnnotationExternalUrl]; ok && len(v) > 0 {
 			opt.DetailsURL = strings.TrimPrefix(v[0], "https://docs.docker.com")
 		} else if _, ok = anchors[flag.Name]; ok {
 			opt.DetailsURL = "#" + flag.Name

--- a/clidocstool_yaml_test.go
+++ b/clidocstool_yaml_test.go
@@ -39,7 +39,7 @@ func TestGenYamlTree(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.GenYamlTree(buildxCmd))
 
-	for _, tt := range []string{"docker_buildx.yaml", "docker_buildx_build.yaml"} {
+	for _, tt := range []string{"docker_buildx.yaml", "docker_buildx_build.yaml", "docker_buildx_stop.yaml"} {
 		tt := tt
 		t.Run(tt, func(t *testing.T) {
 			fres := filepath.Join(tmpdir, tt)

--- a/example/main.go
+++ b/example/main.go
@@ -63,7 +63,6 @@ func gen(opts *options) error {
 	if err != nil {
 		return err
 	}
-	c.DisableFlagsInUseLine()
 
 	// generate all supported docs formats
 	return c.GenAllTree()

--- a/fixtures/buildx.md
+++ b/fixtures/buildx.md
@@ -8,7 +8,14 @@ Build with BuildKit
 | Name | Description |
 | --- | --- |
 | [`build`](buildx_build.md) | Start a build |
+| [`stop`](buildx_stop.md) | Stop builder instance |
 
+
+### Options
+
+| Name | Description |
+| --- | --- |
+| `--builder string` | Override the configured builder instance |
 
 
 <!---MARKER_GEN_END-->

--- a/fixtures/buildx_build.md
+++ b/fixtures/buildx_build.md
@@ -14,6 +14,7 @@ Start a build
 | [`--add-host stringSlice`](https://docs.docker.com/engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host) | Add a custom host-to-IP mapping (host:ip) |
 | `--allow stringSlice` | Allow extra privileged entitlement, e.g. network.host, security.insecure |
 | [`--build-arg stringArray`](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) | Set build-time variables |
+| `--builder string` | Override the configured builder instance |
 | `--cache-from stringArray` | External cache sources (eg. user/app:cache, type=local,src=path/to/dir) |
 | `--cache-to stringArray` | Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir) |
 | `--compress` | Compress the build context using gzip |

--- a/fixtures/buildx_stop.md
+++ b/fixtures/buildx_stop.md
@@ -1,0 +1,14 @@
+# docker buildx stop
+
+<!---MARKER_GEN_START-->
+Stop builder instance
+
+### Options
+
+| Name | Description |
+| --- | --- |
+| `--builder string` | Override the configured builder instance |
+
+
+<!---MARKER_GEN_END-->
+

--- a/fixtures/docker_buildx_build.yaml
+++ b/fixtures/docker_buildx_build.yaml
@@ -213,6 +213,15 @@ options:
   experimentalcli: false
   kubernetes: false
   swarm: false
+inherited_options:
+- option: builder
+  value_type: string
+  description: Override the configured builder instance
+  deprecated: false
+  experimental: false
+  experimentalcli: false
+  kubernetes: false
+  swarm: false
 deprecated: false
 experimental: false
 experimentalcli: false

--- a/fixtures/docker_buildx_build.yaml
+++ b/fixtures/docker_buildx_build.yaml
@@ -2,7 +2,7 @@ command: docker buildx build
 aliases: b
 short: Start a build
 long: Start a build
-usage: docker buildx build [OPTIONS] PATH | URL | - [flags]
+usage: docker buildx build [OPTIONS] PATH | URL | -
 pname: docker buildx
 plink: docker_buildx.yaml
 options:

--- a/fixtures/docker_buildx_stop.yaml
+++ b/fixtures/docker_buildx_stop.yaml
@@ -1,15 +1,10 @@
-command: docker buildx
-short: Build with BuildKit
-long: Build with BuildKit
-pname: docker
-plink: docker.yaml
-cname:
-- docker buildx build
-- docker buildx stop
-clink:
-- docker_buildx_build.yaml
-- docker_buildx_stop.yaml
-options:
+command: docker buildx stop
+short: Stop builder instance
+long: Stop builder instance
+usage: docker buildx stop [NAME] [flags]
+pname: docker buildx
+plink: docker_buildx.yaml
+inherited_options:
 - option: builder
   value_type: string
   description: Override the configured builder instance

--- a/fixtures/docker_buildx_stop.yaml
+++ b/fixtures/docker_buildx_stop.yaml
@@ -1,7 +1,7 @@
 command: docker buildx stop
 short: Stop builder instance
 long: Stop builder instance
-usage: docker buildx stop [NAME] [flags]
+usage: docker buildx stop [NAME]
 pname: docker buildx
 plink: docker_buildx.yaml
 inherited_options:


### PR DESCRIPTION
`hasFlags` for Markdown generation does not cover persistent flags if the current cmd does not have at least one flag defined. For example with `docker buildx stop` command:

```text
$ docker buildx stop --help                                                                                                                         
                                                                                                                                                                                                                
Usage:  docker buildx stop [NAME]                                                                                                                                                                               
                                                                                                                                                                                                                
Stop builder instance                                                                                                                                                                                           
                                                                                                                                                                                                                
Options:                                                                                                                                                                                                        
      --builder string   Override the configured builder instance
```

`builder` flag is not generated:

```
# buildx stop

docker buildx stop [NAME]

<!---MARKER_GEN_START-->
Stop builder instance


<!---MARKER_GEN_END-->

## Description

Stops the specified or current builder. This will not prevent buildx build to
restart the builder. The implementation of stop depends on the driver.
```

With this PR:

```
# buildx stop

docker buildx stop [NAME]

<!---MARKER_GEN_START-->
Stop builder instance

### Options

| Name | Description |
| --- | --- |
| `--builder string` | Override the configured builder instance |


<!---MARKER_GEN_END-->

## Description

Stops the specified or current builder. This will not prevent buildx build to
restart the builder. The implementation of stop depends on the driver.

```

Also added `docs.external.url` as a const.

Will add tests when #9 is merged.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>