### PR TITLE
remove github.com/pkg/errors dependency

### DIFF
--- a/clidocstool.go
+++ b/clidocstool.go
@@ -15,10 +15,10 @@
 package clidocstool
 
 import (
+	"errors"
 	"io"
 	"os"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/clidocstool_md.go
+++ b/clidocstool_md.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -85,10 +84,10 @@ func (c *Client) GenMarkdownTree(cmd *cobra.Command) error {
 	end := strings.Index(cs, "<!---MARKER_GEN_END-->")
 
 	if start == -1 {
-		return errors.Errorf("no start marker in %s", mdFile)
+		return fmt.Errorf("no start marker in %s", mdFile)
 	}
 	if end == -1 {
-		return errors.Errorf("no end marker in %s", mdFile)
+		return fmt.Errorf("no end marker in %s", mdFile)
 	}
 
 	out, err := mdCmdOutput(cmd, cs)
@@ -102,7 +101,7 @@ func (c *Client) GenMarkdownTree(cmd *cobra.Command) error {
 		return err
 	}
 	if err = ioutil.WriteFile(targetPath, []byte(cont), fi.Mode()); err != nil {
-		return errors.Wrapf(err, "failed to write %s", targetPath)
+		return fmt.Errorf("failed to write %s: %w", targetPath, err)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/docker/cli-docs-tool
 go 1.16
 
 require (
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -191,8 +191,6 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.9.3/go.mod h1:u1nR/EPcESfeI/szUZKdtJ0xRNbUoANCkoOuaOx1Y+c=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=


### PR DESCRIPTION
While pkg/errors ia a great utility, I don't think it's adding enough value
in this specific project to make it worth being an extra dependency.
