### PR TITLE
fix desync file copying

### DIFF
--- a/clidocstool.go
+++ b/clidocstool.go
@@ -88,21 +88,17 @@ func fileExists(f string) bool {
 	return !info.IsDir()
 }
 
-func copyFile(src string, dest string) error {
-	srcFile, err := os.Open(src)
+func copyFile(src string, dst string) error {
+	sf, err := os.Open(src)
 	if err != nil {
 		return err
 	}
-	defer srcFile.Close()
-
-	destFile, err := os.Create(dest)
+	defer sf.Close()
+	df, err := os.OpenFile(dst, os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
 		return err
 	}
-	defer destFile.Close()
-
-	if _, err = io.Copy(destFile, srcFile); err != nil {
-		return err
-	}
-	return destFile.Sync()
+	defer df.Close()
+	_, err = io.Copy(df, sf)
+	return err
 }

--- a/clidocstool_md_test.go
+++ b/clidocstool_md_test.go
@@ -31,6 +31,9 @@ func TestGenMarkdownTree(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
+	err = copyFile(path.Join("fixtures", "buildx_stop.pre.md"), path.Join(tmpdir, "buildx_stop.md"))
+	require.NoError(t, err)
+
 	c, err := New(Options{
 		Root:      buildxCmd,
 		SourceDir: tmpdir,

--- a/clidocstool_test.go
+++ b/clidocstool_test.go
@@ -110,6 +110,9 @@ func TestGenAllTree(t *testing.T) {
 	require.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
+	err = copyFile(path.Join("fixtures", "buildx_stop.pre.md"), path.Join(tmpdir, "buildx_stop.md"))
+	require.NoError(t, err)
+
 	c, err := New(Options{
 		Root:      buildxCmd,
 		SourceDir: tmpdir,

--- a/fixtures/buildx_stop.pre.md
+++ b/fixtures/buildx_stop.pre.md
@@ -1,0 +1,5 @@
+# docker buildx stop
+
+<!---MARKER_GEN_START-->
+<!---MARKER_GEN_END-->
+


### PR DESCRIPTION
while testing `v0.2.0` release on buildx repo, I encounter this issue:

```text
#15 0.856 INFO: Generating Markdown for "docker buildx bake"
#15 0.856 ERROR: no start marker in buildx_bake.md
```

happens when file already exists in dest folder which was not currently tested so added a test and fix the desync copy issue.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>