### PR TITLE
yaml: add hidden field for cmd option

### DIFF
--- a/clidocstool_yaml.go
+++ b/clidocstool_yaml.go
@@ -37,6 +37,7 @@ type cmdOption struct {
 	Description     string `yaml:",omitempty"`
 	DetailsURL      string `yaml:"details_url,omitempty"` // DetailsURL contains an anchor-id or link for more information on this flag
 	Deprecated      bool
+	Hidden          bool
 	MinAPIVersion   string `yaml:"min_api_version,omitempty"`
 	Experimental    bool
 	ExperimentalCLI bool
@@ -264,6 +265,7 @@ func genFlagResult(flags *pflag.FlagSet, anchors map[string]struct{}) []cmdOptio
 			DefaultValue: forceMultiLine(flag.DefValue, defaultValueMaxWidth),
 			Description:  forceMultiLine(flag.Usage, descriptionMaxWidth),
 			Deprecated:   len(flag.Deprecated) > 0,
+			Hidden:       flag.Hidden,
 		}
 
 		if v, ok := flag.Annotations[AnnotationExternalUrl]; ok && len(v) > 0 {

--- a/fixtures/docker_buildx.yaml
+++ b/fixtures/docker_buildx.yaml
@@ -14,6 +14,7 @@ options:
   value_type: string
   description: Override the configured builder instance
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/fixtures/docker_buildx_build.yaml
+++ b/fixtures/docker_buildx_build.yaml
@@ -12,6 +12,7 @@ options:
   description: Add a custom host-to-IP mapping (host:ip)
   details_url: /engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -22,6 +23,7 @@ options:
   description: |
     Allow extra privileged entitlement, e.g. network.host, security.insecure
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -32,6 +34,7 @@ options:
   description: Set build-time variables
   details_url: /engine/reference/commandline/build/#set-build-time-variables---build-arg
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -42,6 +45,7 @@ options:
   description: |
     External cache sources (eg. user/app:cache, type=local,src=path/to/dir)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -52,6 +56,7 @@ options:
   description: |
     Cache export destinations (eg. user/app:cache, type=local,dest=path/to/dir)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -61,6 +66,7 @@ options:
   default_value: "false"
   description: Compress the build context using gzip
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -71,6 +77,7 @@ options:
   description: Name of the Dockerfile (Default is 'PATH/Dockerfile')
   details_url: /engine/reference/commandline/build/#specify-a-dockerfile--f
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -79,6 +86,7 @@ options:
   value_type: string
   description: Write the image ID to the file
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -88,6 +96,7 @@ options:
   default_value: '[]'
   description: Set metadata for an image
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -97,6 +106,7 @@ options:
   default_value: "false"
   description: Shorthand for --output=type=docker
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -106,6 +116,7 @@ options:
   default_value: default
   description: Set the networking mode for the RUN instructions during build
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -116,6 +127,7 @@ options:
   default_value: '[]'
   description: 'Output destination (format: type=local,dest=path)'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -125,6 +137,7 @@ options:
   default_value: '[]'
   description: Set target platform for build
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -134,6 +147,7 @@ options:
   default_value: "false"
   description: Shorthand for --output=type=registry
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -144,6 +158,7 @@ options:
   default_value: "false"
   description: Suppress the build output and print image ID on success
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -153,6 +168,7 @@ options:
   default_value: '[]'
   description: 'Secret file to expose to the build: id=mysecret,src=/local/secret'
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -162,6 +178,7 @@ options:
   default_value: '[]'
   description: Security options
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -171,6 +188,7 @@ options:
   default_value: "false"
   description: Squash newly built layers into a single new layer
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -181,6 +199,7 @@ options:
   description: |
     SSH agent socket or keys to expose to the build (format: `default|<id>[=<socket>|<key>[,<key>]]`)
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -192,6 +211,7 @@ options:
   description: Name and optionally a tag in the 'name:tag' format
   details_url: /engine/reference/commandline/build/#tag-an-image--t
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -201,6 +221,7 @@ options:
   description: Set the target build stage to build.
   details_url: /engine/reference/commandline/build/#specifying-target-build-stage---target
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -209,6 +230,7 @@ options:
   value_type: string
   description: Ulimit options
   deprecated: false
+  hidden: true
   experimental: false
   experimentalcli: false
   kubernetes: false
@@ -218,6 +240,7 @@ inherited_options:
   value_type: string
   description: Override the configured builder instance
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false

--- a/fixtures/docker_buildx_stop.yaml
+++ b/fixtures/docker_buildx_stop.yaml
@@ -9,6 +9,7 @@ inherited_options:
   value_type: string
   description: Override the configured builder instance
   deprecated: false
+  hidden: false
   experimental: false
   experimentalcli: false
   kubernetes: false


### PR DESCRIPTION
Like markdown, hidden flags should not be generated for yaml.

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>