### PR TITLE
yaml: root command should also be removed for non-plugin (cli)

### DIFF
--- a/clidocstool_yaml.go
+++ b/clidocstool_yaml.go
@@ -367,7 +367,7 @@ func (c *Client) loadLongDescription(parentCmd *cobra.Command) error {
 			}
 		}
 		name := cmd.CommandPath()
-		if i := strings.Index(name, " "); c.plugin && i >= 0 {
+		if i := strings.Index(name, " "); i >= 0 {
 			// remove root command / binary name
 			name = name[i+1:]
 		}


### PR DESCRIPTION
Encounter this issue while implementing cli-docs-tool on docker/cli: https://github.com/docker/cli/pull/3381/commits/966a470db0a0928536b047d3ac9af83b2fabffd3

Without this change I have to rename commandline ref md. e.g., `build.md` > `docker_build.md` which would break links on `docs.docker.com`:

![image](https://user-images.githubusercontent.com/1951866/149972231-5bb003de-2a3a-47c8-99d0-8d5e3896a8e8.png)


Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>