### PR TITLE
replace uses of os/ioutil, and use test.TempDir() in tests

### DIFF
--- a/clidocstool_md.go
+++ b/clidocstool_md.go
@@ -17,7 +17,6 @@ package clidocstool
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -82,14 +81,14 @@ func (c *Client) GenMarkdownTree(cmd *cobra.Command) error {
 		}); err != nil {
 			return err
 		}
-		if err = ioutil.WriteFile(targetPath, icBuf.Bytes(), 0644); err != nil {
+		if err = os.WriteFile(targetPath, icBuf.Bytes(), 0644); err != nil {
 			return err
 		}
 	} else if err := copyFile(sourcePath, targetPath); err != nil {
 		return err
 	}
 
-	content, err := ioutil.ReadFile(targetPath)
+	content, err := os.ReadFile(targetPath)
 	if err != nil {
 		return err
 	}
@@ -116,7 +115,7 @@ func (c *Client) GenMarkdownTree(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	if err = ioutil.WriteFile(targetPath, []byte(cont), fi.Mode()); err != nil {
+	if err = os.WriteFile(targetPath, []byte(cont), fi.Mode()); err != nil {
 		return fmt.Errorf("failed to write %s: %w", targetPath, err)
 	}
 

--- a/clidocstool_md_test.go
+++ b/clidocstool_md_test.go
@@ -15,7 +15,6 @@
 package clidocstool
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -27,11 +26,9 @@ import (
 
 //nolint:errcheck
 func TestGenMarkdownTree(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test-gen-markdown-tree")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
-	err = copyFile(path.Join("fixtures", "buildx_stop.pre.md"), path.Join(tmpdir, "buildx_stop.md"))
+	err := copyFile(path.Join("fixtures", "buildx_stop.pre.md"), path.Join(tmpdir, "buildx_stop.md"))
 	require.NoError(t, err)
 
 	c, err := New(Options{
@@ -45,12 +42,10 @@ func TestGenMarkdownTree(t *testing.T) {
 	for _, tt := range []string{"buildx.md", "buildx_build.md", "buildx_stop.md"} {
 		tt := tt
 		t.Run(tt, func(t *testing.T) {
-			fres := filepath.Join(tmpdir, tt)
-			require.FileExists(t, fres)
-			bres, err := ioutil.ReadFile(fres)
+			bres, err := os.ReadFile(filepath.Join(tmpdir, tt))
 			require.NoError(t, err)
 
-			bexc, err := ioutil.ReadFile(path.Join("fixtures", tt))
+			bexc, err := os.ReadFile(path.Join("fixtures", tt))
 			require.NoError(t, err)
 			assert.Equal(t, string(bexc), string(bres))
 		})

--- a/clidocstool_test.go
+++ b/clidocstool_test.go
@@ -15,7 +15,6 @@
 package clidocstool
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -175,11 +174,9 @@ func init() {
 
 //nolint:errcheck
 func TestGenAllTree(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test-gen-all-tree")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
-	err = copyFile(path.Join("fixtures", "buildx_stop.pre.md"), path.Join(tmpdir, "buildx_stop.md"))
+	err := copyFile(path.Join("fixtures", "buildx_stop.pre.md"), path.Join(tmpdir, "buildx_stop.md"))
 	require.NoError(t, err)
 
 	c, err := New(Options{
@@ -193,12 +190,10 @@ func TestGenAllTree(t *testing.T) {
 	for _, tt := range []string{"buildx.md", "buildx_build.md", "buildx_stop.md", "docker_buildx.yaml", "docker_buildx_build.yaml", "docker_buildx_stop.yaml"} {
 		tt := tt
 		t.Run(tt, func(t *testing.T) {
-			fres := filepath.Join(tmpdir, tt)
-			require.FileExists(t, fres)
-			bres, err := ioutil.ReadFile(fres)
+			bres, err := os.ReadFile(filepath.Join(tmpdir, tt))
 			require.NoError(t, err)
 
-			bexc, err := ioutil.ReadFile(path.Join("fixtures", tt))
+			bexc, err := os.ReadFile(path.Join("fixtures", tt))
 			require.NoError(t, err)
 			assert.Equal(t, string(bexc), string(bres))
 		})

--- a/clidocstool_yaml.go
+++ b/clidocstool_yaml.go
@@ -17,7 +17,6 @@ package clidocstool
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -376,7 +375,7 @@ func (c *Client) loadLongDescription(parentCmd *cobra.Command) error {
 		}
 		mdFile := strings.ReplaceAll(name, " ", "_") + ".md"
 		sourcePath := filepath.Join(c.source, mdFile)
-		content, err := ioutil.ReadFile(sourcePath)
+		content, err := os.ReadFile(sourcePath)
 		if os.IsNotExist(err) {
 			log.Printf("WARN: %s does not exist, skipping Markdown examples for YAML doc\n", mdFile)
 			continue

--- a/clidocstool_yaml_test.go
+++ b/clidocstool_yaml_test.go
@@ -15,7 +15,6 @@
 package clidocstool
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -27,9 +26,7 @@ import (
 
 //nolint:errcheck
 func TestGenYamlTree(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "test-gen-yaml-tree")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	c, err := New(Options{
 		Root:      buildxCmd,
@@ -42,12 +39,10 @@ func TestGenYamlTree(t *testing.T) {
 	for _, tt := range []string{"docker_buildx.yaml", "docker_buildx_build.yaml", "docker_buildx_stop.yaml"} {
 		tt := tt
 		t.Run(tt, func(t *testing.T) {
-			fres := filepath.Join(tmpdir, tt)
-			require.FileExists(t, fres)
-			bres, err := ioutil.ReadFile(fres)
+			bres, err := os.ReadFile(filepath.Join(tmpdir, tt))
 			require.NoError(t, err)
 
-			bexc, err := ioutil.ReadFile(path.Join("fixtures", tt))
+			bexc, err := os.ReadFile(path.Join("fixtures", tt))
 			require.NoError(t, err)
 			assert.Equal(t, string(bexc), string(bres))
 		})


### PR DESCRIPTION
The os/ioutil package is now deprecated, so replace with os. While at it,
also replace its used for test.TempDir() in tests, which is easier to use
as it is automatically cleaned up.
