### PR TITLE
markdown: make sure we don't ignore headers with trailing whitespace

### DIFF
--- a/markdown.go
+++ b/markdown.go
@@ -42,7 +42,7 @@ func getSections(mdString string) map[string]string {
 		}
 		parts := strings.SplitN(s, "\n", 2)
 		if len(parts) == 2 {
-			sections[strings.ToLower(parts[0])] = parts[1]
+			sections[strings.ToLower(strings.TrimSpace(parts[0]))] = parts[1]
 		}
 	}
 	return sections


### PR DESCRIPTION
do we have a test for this already somewhere? (i.e. a test that combines markdown "examples" with the output generated from the command?)