### PR TITLE
ci: remove dependabot for gomod

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,13 +1,5 @@
 version: 2
 updates:
-  - package-ecosystem: "gomod"
-    open-pull-requests-limit: 10
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels:
-      - "dependencies"
-      - "bot"
   - package-ecosystem: "github-actions"
     open-pull-requests-limit: 10
     directory: "/"


### PR DESCRIPTION
follow-up https://github.com/docker/cli-docs-tool/pull/17#issuecomment-1062880343
closes #17 

Signed-off-by: CrazyMax <crazy-max@users.noreply.github.com>