### PR TITLE
use full command as aliases

### DIFF
--- a/clidocstool.go
+++ b/clidocstool.go
@@ -97,3 +97,19 @@ func copyFile(src string, dst string) error {
 	_, err = io.Copy(df, sf)
 	return err
 }
+
+func getAliases(cmd *cobra.Command) []string {
+	if len(cmd.Aliases) == 0 {
+		return cmd.Aliases
+	}
+
+	var parentPath string
+	if cmd.HasParent() {
+		parentPath = cmd.Parent().CommandPath() + " "
+	}
+	aliases := []string{cmd.CommandPath()}
+	for _, a := range cmd.Aliases {
+		aliases = append(aliases, parentPath+a)
+	}
+	return aliases
+}

--- a/clidocstool_md.go
+++ b/clidocstool_md.go
@@ -155,11 +155,9 @@ func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 		fmt.Fprintf(b, "%s\n\n", desc)
 	}
 
-	if len(cmd.Aliases) != 0 {
-		fmt.Fprintf(b, "### Aliases\n\n`%s`", cmd.Name())
-		for _, a := range cmd.Aliases {
-			fmt.Fprintf(b, ", `%s`", a)
-		}
+	if aliases := getAliases(cmd); len(aliases) != 0 {
+		fmt.Fprint(b, "### Aliases\n\n")
+		fmt.Fprint(b, "`"+strings.Join(aliases, "`, `")+"`")
 		fmt.Fprint(b, "\n\n")
 	}
 

--- a/clidocstool_yaml.go
+++ b/clidocstool_yaml.go
@@ -150,7 +150,7 @@ func (c *Client) genYamlCustom(cmd *cobra.Command, w io.Writer) error {
 
 	cliDoc := cmdDoc{
 		Name:       cmd.CommandPath(),
-		Aliases:    strings.Join(cmd.Aliases, ", "),
+		Aliases:    strings.Join(getAliases(cmd), ", "),
 		Short:      forceMultiLine(cmd.Short, shortMaxWidth),
 		Long:       forceMultiLine(cmd.Long, longMaxWidth),
 		Example:    cmd.Example,

--- a/fixtures/buildx_build.md
+++ b/fixtures/buildx_build.md
@@ -5,7 +5,7 @@ Start a build
 
 ### Aliases
 
-`build`, `b`
+`docker buildx build`, `docker buildx b`
 
 ### Options
 

--- a/fixtures/docker_buildx_build.yaml
+++ b/fixtures/docker_buildx_build.yaml
@@ -1,5 +1,5 @@
 command: docker buildx build
-aliases: b
+aliases: docker buildx build, docker buildx b
 short: Start a build
 long: Start a build
 usage: docker buildx build [OPTIONS] PATH | URL | -


### PR DESCRIPTION
- relates to https://github.com/docker/cli/pull/3693

The default output for Cobra aliases only shows the subcommand as alias, which
is not very intuitive. This patch changes the output to use the full command
as it would be called by the user.

Before this patch:

    aliases: build, b

After this patch:

    aliases: docker buildx build, docker buildx b

Note that there's still some improvements to be made; due to how aliases must be
set-up in Cobra, aliases at different "levels" are still not shown. So for example,
`docker build --help` will not show `docker buildx build` as alias, and vice-versa.
This will require additional changes, and can possibly be resolved using custom
metadata/annotations.
