### PR TITLE
markdown: format generated tables to have equal-width columns

### DIFF
--- a/clidocstool_md.go
+++ b/clidocstool_md.go
@@ -157,43 +157,43 @@ func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 		desc = cmd.Long
 	}
 	if desc != "" {
-		fmt.Fprintf(b, "%s\n\n", desc)
+		b.WriteString(desc + "\n\n")
 	}
 
 	if aliases := getAliases(cmd); len(aliases) != 0 {
-		fmt.Fprint(b, "### Aliases\n\n")
-		fmt.Fprint(b, "`"+strings.Join(aliases, "`, `")+"`")
-		fmt.Fprint(b, "\n\n")
+		b.WriteString("### Aliases\n\n")
+		b.WriteString("`" + strings.Join(aliases, "`, `") + "`")
+		b.WriteString("\n\n")
 	}
 
 	if len(cmd.Commands()) != 0 {
-		fmt.Fprint(b, "### Subcommands\n\n")
-		fmt.Fprint(b, "| Name | Description |\n")
-		fmt.Fprint(b, "| --- | --- |\n")
+		b.WriteString("### Subcommands\n\n")
+		b.WriteString("| Name | Description |\n")
+		b.WriteString("| --- | --- |\n")
 		for _, c := range cmd.Commands() {
-			fmt.Fprintf(b, "| [`%s`](%s) | %s |\n", c.Name(), mdFilename(c), c.Short)
+			b.WriteString(fmt.Sprintf("| [`%s`](%s) | %s |\n", c.Name(), mdFilename(c), c.Short))
 		}
-		fmt.Fprint(b, "\n\n")
+		b.WriteString("\n\n")
 	}
 
 	// add inherited flags before checking for flags availability
 	cmd.Flags().AddFlagSet(cmd.InheritedFlags())
 
 	if cmd.Flags().HasAvailableFlags() {
-		fmt.Fprint(b, "### Options\n\n")
-		fmt.Fprint(b, "| Name | Type | Default | Description |\n")
-		fmt.Fprint(b, "| --- | --- | --- | --- |\n")
+		b.WriteString("### Options\n\n")
+		b.WriteString("| Name | Type | Default | Description |\n")
+		b.WriteString("| --- | --- | --- | --- |\n")
 
 		cmd.Flags().VisitAll(func(f *pflag.Flag) {
 			if f.Hidden {
 				return
 			}
 			isLink := strings.Contains(old, "<a name=\""+f.Name+"\"></a>")
-			fmt.Fprint(b, "| ")
+			b.WriteString("| ")
 			if f.Shorthand != "" {
 				name := "`-" + f.Shorthand + "`"
 				name = mdMakeLink(name, f.Name, f, isLink)
-				fmt.Fprintf(b, "%s, ", name)
+				b.WriteString(name + ", ")
 			}
 			name := "`--" + f.Name + "`"
 			name = mdMakeLink(name, f.Name, f, isLink)
@@ -221,9 +221,9 @@ func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 			} else if cd, ok := cmd.Annotations[annotation.CodeDelimiter]; ok {
 				usage = strings.ReplaceAll(usage, cd, "`")
 			}
-			fmt.Fprintf(b, "%s | %s | %s | %s |\n", mdEscapePipe(name), mdEscapePipe(ftype), mdEscapePipe(defval), mdReplaceNewline(mdEscapePipe(usage)))
+			b.WriteString(fmt.Sprintf("%s | %s | %s | %s |\n", mdEscapePipe(name), mdEscapePipe(ftype), mdEscapePipe(defval), mdReplaceNewline(mdEscapePipe(usage))))
 		})
-		fmt.Fprintln(b, "")
+		b.WriteString("\n")
 	}
 
 	return b.String(), nil

--- a/fixtures/buildx.md
+++ b/fixtures/buildx.md
@@ -5,17 +5,17 @@ Extended build capabilities with BuildKit
 
 ### Subcommands
 
-| Name | Description |
-| --- | --- |
-| [`build`](buildx_build.md) | Start a build |
-| [`stop`](buildx_stop.md) | Stop builder instance |
+| Name                       | Description           |
+|:---------------------------|:----------------------|
+| [`build`](buildx_build.md) | Start a build         |
+| [`stop`](buildx_stop.md)   | Stop builder instance |
 
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| `--builder` | `string` |  | Override the configured builder instance |
+| Name        | Type     | Default | Description                              |
+|:------------|:---------|:--------|:-----------------------------------------|
+| `--builder` | `string` |         | Override the configured builder instance |
 
 
 <!---MARKER_GEN_END-->

--- a/fixtures/buildx_build.md
+++ b/fixtures/buildx_build.md
@@ -9,30 +9,30 @@ Start a build
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| [`--add-host`](https://docs.docker.com/engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host) | `stringSlice` |  | Add a custom host-to-IP mapping (format: `host:ip`) |
-| `--allow` | `stringSlice` |  | Allow extra privileged entitlement (e.g., `network.host`, `security.insecure`) |
-| [`--build-arg`](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg) | `stringArray` |  | Set build-time variables |
-| `--builder` | `string` |  | Override the configured builder instance |
-| `--cache-from` | `stringArray` |  | External cache sources (e.g., `user/app:cache`, `type=local,src=path/to/dir`) |
-| `--cache-to` | `stringArray` |  | Cache export destinations (e.g., `user/app:cache`, `type=local,dest=path/to/dir`) |
-| [`--cgroup-parent`](https://docs.docker.com/engine/reference/commandline/build/#use-a-custom-parent-cgroup---cgroup-parent) | `string` |  | Optional parent cgroup for the container |
-| [`-f`](https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f), [`--file`](https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f) | `string` |  | Name of the Dockerfile (default: `PATH/Dockerfile`) |
-| `--iidfile` | `string` |  | Write the image ID to the file |
-| `--label` | `stringArray` |  | Set metadata for an image |
-| `--load` |  |  | Shorthand for `--output=type=docker` |
-| `--network` | `string` | `default` | Set the networking mode for the `RUN` instructions during build |
-| `-o`, `--output` | `stringArray` |  | Output destination (format: `type=local,dest=path`) |
-| `--platform` | `stringArray` | local | Set target platform for build |
-| `--push` |  |  | Shorthand for `--output=type=registry` |
-| `-q`, `--quiet` |  |  | Suppress the build output and print image ID on success |
-| `--secret` | `stringArray` |  | Secret file to expose to the build (format: `id=mysecret,src=/local/secret`) |
-| `--shm-size` | `string` |  | Size of `/dev/shm` |
-| `--ssh` | `stringArray` |  | SSH agent socket or keys to expose to the build<br>format: `default\|<id>[=<socket>\|<key>[,<key>]]` |
-| [`-t`](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t), [`--tag`](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t) | `stringArray` |  | Name and optionally a tag (format: `name:tag`) |
-| [`--target`](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target) | `string` |  | Set the target build stage to build. |
-| `--ulimit` | `string` |  | Ulimit options |
+| Name                                                                                                                                                                                         | Type          | Default   | Description                                                                                          |
+|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:--------------|:----------|:-----------------------------------------------------------------------------------------------------|
+| [`--add-host`](https://docs.docker.com/engine/reference/commandline/build/#add-entries-to-container-hosts-file---add-host)                                                                   | `stringSlice` |           | Add a custom host-to-IP mapping (format: `host:ip`)                                                  |
+| `--allow`                                                                                                                                                                                    | `stringSlice` |           | Allow extra privileged entitlement (e.g., `network.host`, `security.insecure`)                       |
+| [`--build-arg`](https://docs.docker.com/engine/reference/commandline/build/#set-build-time-variables---build-arg)                                                                            | `stringArray` |           | Set build-time variables                                                                             |
+| `--builder`                                                                                                                                                                                  | `string`      |           | Override the configured builder instance                                                             |
+| `--cache-from`                                                                                                                                                                               | `stringArray` |           | External cache sources (e.g., `user/app:cache`, `type=local,src=path/to/dir`)                        |
+| `--cache-to`                                                                                                                                                                                 | `stringArray` |           | Cache export destinations (e.g., `user/app:cache`, `type=local,dest=path/to/dir`)                    |
+| [`--cgroup-parent`](https://docs.docker.com/engine/reference/commandline/build/#use-a-custom-parent-cgroup---cgroup-parent)                                                                  | `string`      |           | Optional parent cgroup for the container                                                             |
+| [`-f`](https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f), [`--file`](https://docs.docker.com/engine/reference/commandline/build/#specify-a-dockerfile--f) | `string`      |           | Name of the Dockerfile (default: `PATH/Dockerfile`)                                                  |
+| `--iidfile`                                                                                                                                                                                  | `string`      |           | Write the image ID to the file                                                                       |
+| `--label`                                                                                                                                                                                    | `stringArray` |           | Set metadata for an image                                                                            |
+| `--load`                                                                                                                                                                                     |               |           | Shorthand for `--output=type=docker`                                                                 |
+| `--network`                                                                                                                                                                                  | `string`      | `default` | Set the networking mode for the `RUN` instructions during build                                      |
+| `-o`, `--output`                                                                                                                                                                             | `stringArray` |           | Output destination (format: `type=local,dest=path`)                                                  |
+| `--platform`                                                                                                                                                                                 | `stringArray` | local     | Set target platform for build                                                                        |
+| `--push`                                                                                                                                                                                     |               |           | Shorthand for `--output=type=registry`                                                               |
+| `-q`, `--quiet`                                                                                                                                                                              |               |           | Suppress the build output and print image ID on success                                              |
+| `--secret`                                                                                                                                                                                   | `stringArray` |           | Secret file to expose to the build (format: `id=mysecret,src=/local/secret`)                         |
+| `--shm-size`                                                                                                                                                                                 | `string`      |           | Size of `/dev/shm`                                                                                   |
+| `--ssh`                                                                                                                                                                                      | `stringArray` |           | SSH agent socket or keys to expose to the build<br>format: `default\|<id>[=<socket>\|<key>[,<key>]]` |
+| [`-t`](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t), [`--tag`](https://docs.docker.com/engine/reference/commandline/build/#tag-an-image--t)                  | `stringArray` |           | Name and optionally a tag (format: `name:tag`)                                                       |
+| [`--target`](https://docs.docker.com/engine/reference/commandline/build/#specifying-target-build-stage---target)                                                                             | `string`      |           | Set the target build stage to build.                                                                 |
+| `--ulimit`                                                                                                                                                                                   | `string`      |           | Ulimit options                                                                                       |
 
 
 <!---MARKER_GEN_END-->

--- a/fixtures/buildx_stop.md
+++ b/fixtures/buildx_stop.md
@@ -5,9 +5,9 @@ Stop builder instance
 
 ### Options
 
-| Name | Type | Default | Description |
-| --- | --- | --- | --- |
-| `--builder` | `string` |  | Override the configured builder instance |
+| Name        | Type     | Default | Description                              |
+|:------------|:---------|:--------|:-----------------------------------------|
+| `--builder` | `string` |         | Override the configured builder instance |
 
 
 <!---MARKER_GEN_END-->


### PR DESCRIPTION
This makes the tables more readable when reading the source code.
