### PR TITLE
markdown: annotation to disable docs generation for flag and command

### DIFF
--- a/annotation/annotation.go
+++ b/annotation/annotation.go
@@ -22,4 +22,7 @@ const (
 	CodeDelimiter = "docs.code-delimiter"
 	// DefaultValue specifies the default value for a flag.
 	DefaultValue = "docs.default-value"
+	// MardownNoGen specifies that the command or flag mparkdown docs should
+	// not be generated.
+	MardownNoGen = "docs.markdown-no-gen"
 )

--- a/clidocstool_md.go
+++ b/clidocstool_md.go
@@ -52,6 +52,9 @@ func (c *Client) GenMarkdownTree(cmd *cobra.Command) error {
 	if c.plugin && !cmd.HasParent() {
 		return nil
 	}
+	if _, ok := cmd.Annotations[annotation.MardownNoGen]; ok {
+		return nil
+	}
 
 	log.Printf("INFO: Generating Markdown for %q", cmd.CommandPath())
 	mdFile := mdFilename(cmd)
@@ -208,6 +211,9 @@ func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 		b.WriteString("### Subcommands\n\n")
 		table := newMdTable("Name", "Description")
 		for _, c := range cmd.Commands() {
+			if _, ok := c.Annotations[annotation.MardownNoGen]; ok {
+				continue
+			}
 			table.AddRow(fmt.Sprintf("[`%s`](%s)", c.Name(), mdFilename(c)), c.Short)
 		}
 		b.WriteString(table.String() + "\n")
@@ -221,6 +227,9 @@ func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 		table := newMdTable("Name", "Type", "Default", "Description")
 		cmd.Flags().VisitAll(func(f *pflag.Flag) {
 			if f.Hidden {
+				return
+			}
+			if _, ok := f.Annotations[annotation.MardownNoGen]; ok {
 				return
 			}
 			isLink := strings.Contains(old, "<a name=\""+f.Name+"\"></a>")

--- a/clidocstool_md_test.go
+++ b/clidocstool_md_test.go
@@ -38,6 +38,7 @@ func TestGenMarkdownTree(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.NoError(t, c.GenMarkdownTree(buildxCmd))
+	require.NoFileExists(t, filepath.Join(tmpdir, "buildx__INTERNAL_SERVE.md"))
 
 	for _, tt := range []string{"buildx.md", "buildx_build.md", "buildx_stop.md"} {
 		tt := tt

--- a/clidocstool_test.go
+++ b/clidocstool_test.go
@@ -31,6 +31,7 @@ var (
 	buildxCmd      *cobra.Command
 	buildxBuildCmd *cobra.Command
 	buildxStopCmd  *cobra.Command
+	buildxServeCmd *cobra.Command
 )
 
 //nolint:errcheck
@@ -66,6 +67,14 @@ func init() {
 		Use:   "stop [NAME]",
 		Short: "Stop builder instance",
 		Run:   func(cmd *cobra.Command, args []string) {},
+	}
+	buildxServeCmd = &cobra.Command{
+		Use:    "_INTERNAL_SERVE [OPTIONS]",
+		Hidden: true,
+		Run:    func(cmd *cobra.Command, args []string) {},
+		Annotations: map[string]string{
+			annotation.MardownNoGen: "",
+		},
 	}
 
 	buildxPFlags := buildxCmd.PersistentFlags()
@@ -174,6 +183,7 @@ format: "default|<id>[=<socket>|<key>[,<key>]]"`)
 
 	buildxCmd.AddCommand(buildxBuildCmd)
 	buildxCmd.AddCommand(buildxStopCmd)
+	buildxCmd.AddCommand(buildxServeCmd)
 	dockerCmd.AddCommand(buildxCmd)
 }
 


### PR DESCRIPTION
Related to https://github.com/docker/docs/pull/17539#pullrequestreview-1479826153

In Buildx 0.11 we have commands for internal use only for which markdown docs should not be generated (https://github.com/docker/buildx/blame/master/docs/reference/buildx.md#L14). The new annotation `docs.markdown-no-gen` allows to disable docs generation for specific flag/command.