### PR TITLE
Take hidden attribute into account

### DIFF
--- a/clidocstool_md.go
+++ b/clidocstool_md.go
@@ -53,6 +53,12 @@ func (c *Client) GenMarkdownTree(cmd *cobra.Command) error {
 		return nil
 	}
 
+	// Skip hidden command
+	if cmd.Hidden {
+		log.Printf("INFO: Skipping Markdown for %q (hidden command)", cmd.CommandPath())
+		return nil
+	}
+
 	log.Printf("INFO: Generating Markdown for %q", cmd.CommandPath())
 	mdFile := mdFilename(cmd)
 	sourcePath := filepath.Join(c.source, mdFile)
@@ -208,6 +214,9 @@ func mdCmdOutput(cmd *cobra.Command, old string) (string, error) {
 		b.WriteString("### Subcommands\n\n")
 		table := newMdTable("Name", "Description")
 		for _, c := range cmd.Commands() {
+			if c.Hidden {
+				continue
+			}
 			table.AddRow(fmt.Sprintf("[`%s`](%s)", c.Name(), mdFilename(c)), c.Short)
 		}
 		b.WriteString(table.String() + "\n")

--- a/clidocstool_test.go
+++ b/clidocstool_test.go
@@ -27,10 +27,11 @@ import (
 )
 
 var (
-	dockerCmd      *cobra.Command
-	buildxCmd      *cobra.Command
-	buildxBuildCmd *cobra.Command
-	buildxStopCmd  *cobra.Command
+	dockerCmd        *cobra.Command
+	buildxCmd        *cobra.Command
+	buildxBuildCmd   *cobra.Command
+	buildxInstallCmd *cobra.Command
+	buildxStopCmd    *cobra.Command
 )
 
 //nolint:errcheck
@@ -61,6 +62,13 @@ func init() {
 		Annotations: map[string]string{
 			"aliases": "docker image build, docker buildx build, docker buildx b, docker build",
 		},
+	}
+	buildxInstallCmd = &cobra.Command{
+		Use:    "install",
+		Short:  "Install buildx as a 'docker builder' alias",
+		Args:   cobra.ExactArgs(0),
+		Run:    func(cmd *cobra.Command, args []string) {},
+		Hidden: true,
 	}
 	buildxStopCmd = &cobra.Command{
 		Use:   "stop [NAME]",
@@ -173,6 +181,7 @@ format: "default|<id>[=<socket>|<key>[,<key>]]"`)
 	buildxBuildFlags.MarkHidden("force-rm")
 
 	buildxCmd.AddCommand(buildxBuildCmd)
+	buildxCmd.AddCommand(buildxInstallCmd)
 	buildxCmd.AddCommand(buildxStopCmd)
 	dockerCmd.AddCommand(buildxCmd)
 }
@@ -192,7 +201,7 @@ func TestGenAllTree(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.GenAllTree())
 
-	for _, tt := range []string{"buildx.md", "buildx_build.md", "buildx_stop.md", "docker_buildx.yaml", "docker_buildx_build.yaml", "docker_buildx_stop.yaml"} {
+	for _, tt := range []string{"buildx.md", "buildx_build.md", "buildx_stop.md", "docker_buildx.yaml", "docker_buildx_build.yaml", "docker_buildx_install.yaml", "docker_buildx_stop.yaml"} {
 		tt := tt
 		t.Run(tt, func(t *testing.T) {
 			bres, err := os.ReadFile(filepath.Join(tmpdir, tt))

--- a/clidocstool_yaml.go
+++ b/clidocstool_yaml.go
@@ -62,6 +62,7 @@ type cmdDoc struct {
 	InheritedOptions []cmdOption `yaml:"inherited_options,omitempty"`
 	Example          string      `yaml:"examples,omitempty"`
 	Deprecated       bool
+	Hidden           bool
 	MinAPIVersion    string `yaml:"min_api_version,omitempty"`
 	Experimental     bool
 	ExperimentalCLI  bool
@@ -155,6 +156,7 @@ func (c *Client) genYamlCustom(cmd *cobra.Command, w io.Writer) error {
 		Long:       forceMultiLine(cmd.Long, longMaxWidth),
 		Example:    cmd.Example,
 		Deprecated: len(cmd.Deprecated) > 0,
+		Hidden:     cmd.Hidden,
 	}
 
 	if len(cliDoc.Long) == 0 {

--- a/clidocstool_yaml_test.go
+++ b/clidocstool_yaml_test.go
@@ -36,7 +36,7 @@ func TestGenYamlTree(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, c.GenYamlTree(buildxCmd))
 
-	for _, tt := range []string{"docker_buildx.yaml", "docker_buildx_build.yaml", "docker_buildx_stop.yaml"} {
+	for _, tt := range []string{"docker_buildx.yaml", "docker_buildx_build.yaml", "docker_buildx_install.yaml", "docker_buildx_stop.yaml"} {
 		tt := tt
 		t.Run(tt, func(t *testing.T) {
 			bres, err := os.ReadFile(filepath.Join(tmpdir, tt))

--- a/fixtures/docker_buildx_build.yaml
+++ b/fixtures/docker_buildx_build.yaml
@@ -365,6 +365,7 @@ inherited_options:
       kubernetes: false
       swarm: false
 deprecated: false
+hidden: false
 experimental: false
 experimentalcli: false
 kubernetes: false

--- a/fixtures/docker_buildx_install.yaml
+++ b/fixtures/docker_buildx_install.yaml
@@ -1,15 +1,10 @@
-command: docker buildx
-short: Docker Buildx
-long: Extended build capabilities with BuildKit
-pname: docker
-plink: docker.yaml
-cname:
-    - docker buildx build
-    - docker buildx stop
-clink:
-    - docker_buildx_build.yaml
-    - docker_buildx_stop.yaml
-options:
+command: docker buildx install
+short: Install buildx as a 'docker builder' alias
+long: Install buildx as a 'docker builder' alias
+usage: docker buildx install
+pname: docker buildx
+plink: docker_buildx.yaml
+inherited_options:
     - option: builder
       value_type: string
       description: Override the configured builder instance
@@ -20,7 +15,7 @@ options:
       kubernetes: false
       swarm: false
 deprecated: false
-hidden: false
+hidden: true
 experimental: false
 experimentalcli: false
 kubernetes: false

--- a/fixtures/docker_buildx_stop.yaml
+++ b/fixtures/docker_buildx_stop.yaml
@@ -15,6 +15,7 @@ inherited_options:
       kubernetes: false
       swarm: false
 deprecated: false
+hidden: false
 experimental: false
 experimentalcli: false
 kubernetes: false


### PR DESCRIPTION
follow-up https://github.com/docker/cli-docs-tool/pull/37#issuecomment-1609348402

Set `hidden` attribute for commands in YAML generation so it can be used on docs website. For markdown do not generate docs for hidden commands.