### PR TITLE
yaml: add processing for internal links, and tests

### DIFF
--- a/markdown_test.go
+++ b/markdown_test.go
@@ -84,6 +84,21 @@ This is a line.
 
 Last line.`,
 		},
+		{
+			doc: "Link preprocessing",
+			in: `[link1](https://example.com/)
+[link2](https://docs.docker.com/foo/bar/)
+[link3](buildx_build.md)
+[link4](buildx_imagetools_create.md)
+[link5](buildx_build.md#build-arg)
+[link6](./swarm_join-token.md)`,
+			expected: `[link1](https://example.com/)
+[link2](/foo/bar/)
+[link3](/reference/cli/docker/buildx/build/)
+[link4](/reference/cli/docker/buildx/imagetools/create/)
+[link5](/reference/cli/docker/buildx/build/#build-arg)
+[link6](/reference/cli/docker/swarm/join-token/)`,
+		},
 	}
 	for _, tc := range tests {
 		tc := tc


### PR DESCRIPTION
Relates to:

- https://github.com/docker/docs/pull/19370
- https://github.com/docker/cli/pull/4866
- https://github.com/docker/buildx/pull/2253

Adds a preprocessing step for links when generating yaml,
reformatting internal, relative links between CLI docs.

Internal links between docs have some variation of the following syntax:

- `[linktext](cmd_subcmd.md)`
- `[linktext](./cmd_subcmd.md)`

Links may also contain an optional anchor:

- `[linktext](cmd_subcmd.md#anchor)`
- `[linktext](./cmd_subcmd.md#anchor)`

The added preprocessing step rewrites these links in the yaml conversion to:

- `[linktext](/reference/cli/docker/cmd/subcmd/)`
- `[linktext](/reference/cli/docker/cmd/subcmd/#anchor)`

Also added tests:

- for the above case, and
- for stripping `https://docs.docker.com` from links (preexisting)
