### PR TITLE
update to go1.23, update golangci-lint to v1.62, fix linting issues

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.20"
+          go-version: "1.23"
       -
         name: Download modules
         run: |

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,6 @@ run:
 
 linters:
   enable:
-    - deadcode
     - depguard
     - gofmt
     - goimports
@@ -13,7 +12,6 @@ linters:
     - ineffassign
     - misspell
     - typecheck
-    - varcheck
     - errname
     - makezero
     - whitespace
@@ -21,12 +19,11 @@ linters:
 
 linters-settings:
   depguard:
-    list-type: blacklist
-    include-go-root: true
-    packages:
-      # The io/ioutil package has been deprecated.
-      # https://go.dev/doc/go1.16#ioutil
-      - io/ioutil
+    rules:
+      main:
+        deny:
+          - pkg: io/ioutil
+            desc: The io/ioutil package has been deprecated, see https://go.dev/doc/go1.16#ioutil
   importas:
     no-unaliased: true
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG GO_VERSION="1.18"
+ARG GO_VERSION="1.23"
 ARG GOLANGCI_LINT_VERSION="v1.62"
 ARG ADDLICENSE_VERSION="v1.0.0"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 # limitations under the License.
 
 ARG GO_VERSION="1.18"
-ARG GOLANGCI_LINT_VERSION="v1.45"
+ARG GOLANGCI_LINT_VERSION="v1.62"
 ARG ADDLICENSE_VERSION="v1.0.0"
 
 ARG LICENSE_ARGS="-c cli-docs-tool -l apache"

--- a/clidocstool_man_test.go
+++ b/clidocstool_man_test.go
@@ -57,7 +57,7 @@ func TestGenManTree(t *testing.T) {
 	seen := make(map[string]struct{})
 	remanpage := regexp.MustCompile(`\.\d+$`)
 
-	filepath.Walk("fixtures", func(path string, info fs.FileInfo, err error) error {
+	_ = filepath.Walk("fixtures", func(path string, info fs.FileInfo, _ error) error {
 		fname := filepath.Base(path)
 		// ignore dirs and any file that is not a manpage
 		if info.IsDir() || !remanpage.MatchString(fname) {
@@ -77,7 +77,7 @@ func TestGenManTree(t *testing.T) {
 		return nil
 	})
 
-	filepath.Walk(tmpdir, func(path string, info fs.FileInfo, err error) error {
+	_ = filepath.Walk(tmpdir, func(path string, info fs.FileInfo, _ error) error {
 		fname := filepath.Base(path)
 		// ignore dirs and any file that is not a manpage
 		if info.IsDir() || !remanpage.MatchString(fname) {

--- a/clidocstool_md_test.go
+++ b/clidocstool_md_test.go
@@ -42,7 +42,7 @@ func TestGenMarkdownTree(t *testing.T) {
 
 	seen := make(map[string]struct{})
 
-	filepath.Walk("fixtures", func(path string, info fs.FileInfo, err error) error {
+	_ = filepath.Walk("fixtures", func(path string, info fs.FileInfo, _ error) error {
 		fname := filepath.Base(path)
 		// ignore dirs, .pre.md files and any file that is not a .md file
 		if info.IsDir() || !strings.HasSuffix(fname, ".md") || strings.HasSuffix(fname, ".pre.md") {
@@ -62,7 +62,7 @@ func TestGenMarkdownTree(t *testing.T) {
 		return nil
 	})
 
-	filepath.Walk(tmpdir, func(path string, info fs.FileInfo, err error) error {
+	_ = filepath.Walk(tmpdir, func(path string, info fs.FileInfo, _ error) error {
 		fname := filepath.Base(path)
 		// ignore dirs, .pre.md files and any file that is not a .md file
 		if info.IsDir() || !strings.HasSuffix(fname, ".md") || strings.HasSuffix(fname, ".pre.md") {

--- a/clidocstool_test.go
+++ b/clidocstool_test.go
@@ -49,7 +49,7 @@ func setup() {
 		SilenceUsage:          true,
 		SilenceErrors:         true,
 		TraverseChildren:      true,
-		Run:                   func(cmd *cobra.Command, args []string) {},
+		Run:                   func(*cobra.Command, []string) {},
 		Version:               "20.10.8",
 		DisableFlagsInUseLine: true,
 	}
@@ -65,7 +65,7 @@ func setup() {
 		Annotations: map[string]string{
 			"aliases": "docker container attach, docker attach",
 		},
-		Run: func(cmd *cobra.Command, args []string) {},
+		Run: func(*cobra.Command, []string) {},
 	}
 
 	attachFlags := attachCmd.Flags()
@@ -86,7 +86,7 @@ func setup() {
 		Use:     "build [OPTIONS] PATH | URL | -",
 		Aliases: []string{"b"},
 		Short:   "Start a build",
-		Run:     func(cmd *cobra.Command, args []string) {},
+		Run:     func(*cobra.Command, []string) {},
 		Annotations: map[string]string{
 			"aliases": "docker image build, docker buildx build, docker buildx b, docker build",
 		},
@@ -95,19 +95,19 @@ func setup() {
 		Use:   "dial-stdio",
 		Short: "Proxy current stdio streams to builder instance",
 		Args:  cobra.NoArgs,
-		Run:   func(cmd *cobra.Command, args []string) {},
+		Run:   func(*cobra.Command, []string) {},
 	}
 	buildxInstallCmd = &cobra.Command{
 		Use:    "install",
 		Short:  "Install buildx as a 'docker builder' alias",
 		Args:   cobra.ExactArgs(0),
-		Run:    func(cmd *cobra.Command, args []string) {},
+		Run:    func(*cobra.Command, []string) {},
 		Hidden: true,
 	}
 	buildxStopCmd = &cobra.Command{
 		Use:   "stop [NAME]",
 		Short: "Stop builder instance",
-		Run:   func(cmd *cobra.Command, args []string) {},
+		Run:   func(*cobra.Command, []string) {},
 	}
 
 	buildxPFlags := buildxCmd.PersistentFlags()
@@ -255,7 +255,7 @@ func TestGenAllTree(t *testing.T) {
 
 	seen := make(map[string]struct{})
 
-	filepath.Walk("fixtures", func(path string, info fs.FileInfo, err error) error {
+	_ = filepath.Walk("fixtures", func(path string, info fs.FileInfo, err error) error {
 		fname := filepath.Base(path)
 		// ignore dirs and .pre.md files
 		if info.IsDir() || strings.HasSuffix(fname, ".pre.md") {
@@ -275,7 +275,7 @@ func TestGenAllTree(t *testing.T) {
 		return nil
 	})
 
-	filepath.Walk(tmpdir, func(path string, info fs.FileInfo, err error) error {
+	_ = filepath.Walk(tmpdir, func(path string, info fs.FileInfo, _ error) error {
 		fname := filepath.Base(path)
 		// ignore dirs and .pre.md files
 		if info.IsDir() || strings.HasSuffix(fname, ".pre.md") {

--- a/clidocstool_yaml.go
+++ b/clidocstool_yaml.go
@@ -77,7 +77,7 @@ type cmdDoc struct {
 // subcmds, `sub` and `sub-third`, and `sub` has a subcommand called `third`
 // it is undefined which help output will be in the file `cmd-sub-third.1`.
 func (c *Client) GenYamlTree(cmd *cobra.Command) error {
-	emptyStr := func(s string) string { return "" }
+	emptyStr := func(string) string { return "" }
 	if err := c.loadLongDescription(cmd, "yaml"); err != nil {
 		return err
 	}

--- a/clidocstool_yaml_test.go
+++ b/clidocstool_yaml_test.go
@@ -40,7 +40,7 @@ func TestGenYamlTree(t *testing.T) {
 
 	seen := make(map[string]struct{})
 
-	filepath.Walk("fixtures", func(path string, info fs.FileInfo, err error) error {
+	_ = filepath.Walk("fixtures", func(path string, info fs.FileInfo, _ error) error {
 		fname := filepath.Base(path)
 		// ignore dirs and any file that is not a .yaml file
 		if info.IsDir() || !strings.HasSuffix(fname, ".yaml") {
@@ -60,7 +60,7 @@ func TestGenYamlTree(t *testing.T) {
 		return nil
 	})
 
-	filepath.Walk(tmpdir, func(path string, info fs.FileInfo, err error) error {
+	_ = filepath.Walk(tmpdir, func(path string, info fs.FileInfo, _ error) error {
 		fname := filepath.Base(path)
 		// ignore dirs and any file that is not a .yaml file
 		if info.IsDir() || !strings.HasSuffix(fname, ".yaml") {


### PR DESCRIPTION
### fix linting issues (revive)

    clidocstool_yaml_test.go:63:60: unused-parameter: parameter 'err' seems to be unused, consider removing or renaming it as _ (revive)
        filepath.Walk(tmpdir, func(path string, info fs.FileInfo, err error) error {
                                                                  ^
    clidocstool_man_test.go:80:60: unused-parameter: parameter 'err' seems to be unused, consider removing or renaming it as _ (revive)
        filepath.Walk(tmpdir, func(path string, info fs.FileInfo, err error) error {
                                                                  ^
    clidocstool_test.go:52:31: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
            Run:                   func(cmd *cobra.Command, args []string) {},
                                        ^
    clidocstool_md_test.go:65:60: unused-parameter: parameter 'err' seems to be unused, consider removing or renaming it as _ (revive)
        filepath.Walk(tmpdir, func(path string, info fs.FileInfo, err error) error {
                                                                  ^
    clidocstool_test.go:68:13: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
            Run: func(cmd *cobra.Command, args []string) {},
                      ^
    clidocstool_test.go:89:17: unused-parameter: parameter 'cmd' seems to be unused, consider removing or renaming it as _ (revive)
            Run:     func(cmd *cobra.Command, args []string) {},
                          ^
    clidocstool_yaml.go:80:19: unused-parameter: parameter 's' seems to be unused, consider removing or renaming it as _ (revive)
        emptyStr := func(s string) string { return "" }
                         ^

### update golangci-lint to v1.62

Update config file for the new version, and removed some linters that were
deprecated and removed;

    WARN The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused.
    ERRO [linters_context] deadcode: This linter is fully inactivated: it will not produce any reports.
    ERRO [linters_context] varcheck: This linter is fully inactivated: it will not produce any reports.

### update to go1.23
