### PR TITLE
Dockerfile: bump ghcr.io/google/addlicense:v1.1.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@
 
 ARG GO_VERSION="1.18"
 ARG GOLANGCI_LINT_VERSION="v1.45"
-ARG ADDLICENSE_VERSION="v1.0.0"
+ARG ADDLICENSE_VERSION="v1.1.1"
 
 ARG LICENSE_ARGS="-c cli-docs-tool -l apache"
 ARG LICENSE_FILES=".*\(Dockerfile\|\.go\|\.hcl\|\.sh\)"


### PR DESCRIPTION
Was hoping this would be a multi-platform image, but it's still single-arch;

     1 warning found (use docker --debug to expand):
     - InvalidBaseImagePlatform: Base image ghcr.io/google/addlicense:v1.0.0 was pulled with platform "linux/amd64", expected "linux/arm64" for current build (line 25)