### PR TITLE
ci: update bake-action to v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,27 +10,42 @@ on:
   pull_request:
 
 jobs:
-  validate:
+  prepare-validate:
     runs-on: ubuntu-latest
+    outputs:
+      targets: ${{ steps.generate.outputs.targets }}
     steps:
       -
         name: Checkout
         uses: actions/checkout@v4
       -
-        name: Run
-        uses: docker/bake-action@v5
+        name: List targets
+        id: generate
+        uses: docker/bake-action/subaction/list-targets@v6
         with:
-          targets: validate
+          target: validate
+
+  validate:
+    runs-on: ubuntu-latest
+    needs:
+      - prepare-validate
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ${{ fromJson(needs.prepare-validate.outputs.targets) }}
+    steps:
+      -
+        name: Validate
+        uses: docker/bake-action@v6
+        with:
+          targets: ${{ matrix.target }}
 
   test:
     runs-on: ubuntu-latest
     steps:
       -
-        name: Checkout
-        uses: actions/checkout@v4
-      -
-        name: Run
-        uses: docker/bake-action@v5
+        name: Test
+        uses: docker/bake-action@v6
         with:
           targets: test
       -

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -12,6 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+target "_common" {
+  args = {
+    BUILDKIT_CONTEXT_KEEP_GIT_DIR = 1
+  }
+}
+
 group "default" {
   targets = ["test"]
 }
@@ -21,31 +27,37 @@ group "validate" {
 }
 
 target "lint" {
+  inherits = ["_common"]
   target = "lint"
   output = ["type=cacheonly"]
 }
 
 target "vendor-validate" {
+  inherits = ["_common"]
   target = "vendor-validate"
   output = ["type=cacheonly"]
 }
 
 target "vendor-update" {
+  inherits = ["_common"]
   target = "vendor-update"
   output = ["."]
 }
 
 target "test" {
+  inherits = ["_common"]
   target = "test-coverage"
   output = ["."]
 }
 
 target "license-validate" {
+  inherits = ["_common"]
   target = "license-validate"
   output = ["type=cacheonly"]
 }
 
 target "license-update" {
+  inherits = ["_common"]
   target = "license-update"
   output = ["."]
 }


### PR DESCRIPTION
closes #62 

Update bake-action to v6 and also distribute validate targets to dedicated runners.